### PR TITLE
Faster recursive chown of /srv for slow disks/lots of files

### DIFF
--- a/system/sbin/kazoo-couchdb
+++ b/system/sbin/kazoo-couchdb
@@ -46,7 +46,7 @@ fi
 
 prepare() {
     mkdir -p ${HOME}
-    chown -R ${USER}:${GROUP} ${HOME}
+    find ${HOME} -print0 | xargs -0 chown ${USER}:${GROUP}
     mkdir -p /var/log/couchdb
     chown -R ${USER}:${GROUP} /var/log/couchdb
     mkdir -p /var/run/couchdb


### PR DESCRIPTION
We have a large number of files under /srv/view_index/.shards and that path is a mount of a slow disk. `chown -R` is a slow operation. See [https://unix.stackexchange.com/a/341617](https://unix.stackexchange.com/a/341617) for an explanation. The new code takes 17s to the old code's 2m20s to perform the recursive chown.