### PR TITLE
Fix `sbin` scripts for Grep v3+

### DIFF
--- a/system/sbin/kazoo-couchdb
+++ b/system/sbin/kazoo-couchdb
@@ -79,12 +79,10 @@ start() {
 }
 
 stop() {
-    for i in `pidof ${BEAM}`; do
-        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+couchdb"; then
-            kill $i
-            RETVAL=$?
-        fi
-    done
+    if PID=$(find_beam_pid); then
+        kill "$PID"
+        RETVAL=$?
+    fi
 }
 
 restart() {
@@ -93,30 +91,37 @@ restart() {
 }
 
 status() {
-    for i in `pidof ${BEAM}`; do
-        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+couchdb"; then
-            echo "couchdb (pid $i) is running..."
-            if which curl &>/dev/null; then
-                curl localhost:5984/_membership
-            fi
-            RETVAL=0
+    if PID=$(find_beam_pid); then
+        echo "couchdb (pid $PID) is running..."
+
+        if which curl &>/dev/null; then
+            curl localhost:5984/_membership
         fi
-    done
+
+        RETVAL=0
+    fi
     if [ ${RETVAL} -eq 1 ]; then
         echo "couchdb is not running!"
     fi
 }
 
 pid() {
-    for i in `pidof ${BEAM}`; do
-        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+couchdb"; then
-            echo $i
-            RETVAL=0
-        fi
-    done
+    find_beam_pid
+    RETVAL=$?
     if [ ${RETVAL} -eq 1 ]; then
         echo "couchdb is not running!"
     fi
+}
+
+find_beam_pid() {
+    for PID in $(pidof $BEAM); do
+        if tr '\0' ' ' < /proc/"$PID"/cmdline | grep -Eq "name[^\-]+couchdb"; then
+            echo "$PID"
+            return 0
+        fi
+    done
+
+    return 1
 }
 
 case "$1" in


### PR DESCRIPTION
Apply similar change as https://github.com/2600hz/kazoo-configs-core/pull/22

It seems when using Grep v3+ (not exactly sure on the breaking change version), that the `NUL` characters separating args in `/proc/$PID/cmdline` don't match the `[^\-]` character class. This means that the `beam` PIDs can't be found. This PR uses `tr` to replace the `NUL` characters with spaces so the `grep` succeeds. Tested backwards-compatibility with Grep v2.

Also DRY'd up the PID find with a shared function and ran these changes thru ShellCheck.